### PR TITLE
Arguments with upper-case values.

### DIFF
--- a/js/lib/SS.js
+++ b/js/lib/SS.js
@@ -9,7 +9,7 @@
     for (var key in routes) {
       regify(routes[key]);
       if (key.indexOf(':') !== -1) {
-        var newKey = key.replace(/:.*?\/|:.*?$/g, '([a-z0-9-]+)/').slice(0, -1);
+        var newKey = key.replace(/:.*?\/|:.*?$/g, '([a-zA-Z0-9-]+)/').slice(0, -1);
         routes[newKey] = routes[key];
         delete routes[key];
       }

--- a/js/test/ss-test-new.js
+++ b/js/test/ss-test-new.js
@@ -497,6 +497,19 @@ createTest('resource object.', {
   });
 });
 
+createTest('argument matching should be case agnostic', {
+  '/fooBar/:name': {
+      on: function(name) {
+        shared.fired.push("fooBar-" + name);
+      }
+    }
+}, function() {
+  shared.fired = [];
+  this.navigate('/fooBar/tesTing', function() {
+    deepEqual(shared.fired, ['fooBar-tesTing']);
+    this.finish();
+  });
+});
 
 
 


### PR DESCRIPTION
Hi,

small fix (with test) for matching:

```
/foo/Bar 
```

to:

```
/foo/:name 
```
