### PR TITLE
IE < 9 doesn't support forEach method

### DIFF
--- a/js/lib/SS.js
+++ b/js/lib/SS.js
@@ -29,10 +29,10 @@ if (!Array.isArray){
 function _flatten (arr) {
   var flat = [];
 
-  arr.forEach(function (a) {
-    flat = flat.concat(a);
-  });
-
+  for (var i = 0, n = arr.length; i < n; i++) {
+    flat = flat.concat(arr[i]);
+  }
+  
   return flat;
 }
 


### PR DESCRIPTION
I replaced array forEach method in _flatten function with simple for loop because it was causing error in IE < 9. I have one question - when I apply this patch SS works as expected in all browsers except IE 7 when I try to navigate back and forth in history - should I create a new issue for this?
