### PR TITLE
[fix] Fix routing when `async` option is on

### DIFF
--- a/lib/sugarskull/router.js
+++ b/lib/sugarskull/router.js
@@ -335,7 +335,10 @@ Router.prototype.invoke = function (fns, thisArg, callback) {
 
   if (this.async) {
     _asyncEverySeries(fns, function (fn, next) {
-      fn.apply(thisArg, fns.captures.concat(next));
+      if (typeof fn == 'function') {
+        fn.apply(thisArg, fns.captures.concat(next));
+      }
+      next();
     }, function () {
       //
       // Ignore the response here. Let the routed take care


### PR DESCRIPTION
Changes:
- don't try to call non-function
- call `next` to go to next handler and finish handling the request (before that requests were hanging infinitely)
