### PR TITLE
Fix CLI doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ Director supports Command Line Interface routing. Routes for cli options are bas
   router.on(/destroy/, function () {
     console.log('destroy something');
   });
+
+  router.dispatch('on', process.argv.slice(2).join(' '));
+```
+
+When the script is run (we'll call it `cli-program.js`), it will route based on the command you give it:
+
+``` bash
+$ node cli-program.js create
+create something
+$ node cli-program.js destroy
+destroy something
 ```
 
 <a name="api-documentation"></a>


### PR DESCRIPTION
The current doc gives the impression that process.argv is parsed automatically, but you have to add a `dispatch()` call.

I simply added this call and an example of how to run the program.
