### PR TITLE
[fix] Wait for `process.nextTick` if the Request has not drained yet

### DIFF
--- a/lib/director/http/index.js
+++ b/lib/director/http/index.js
@@ -109,24 +109,26 @@ Router.prototype.dispatch = function (req, res, callback) {
   }
   
   if (!stream) {
-    //
-    // If there is no streaming required on any of the functions on the 
-    // way to `path`, then attempt to parse the fully buffered request stream
-    // once it has emitted the `end` event.
-    //
-    if (req.readable) {
+    process.nextTick(function () {
       //
-      // If the `http.ServerRequest` is still readable, then await
-      // the end event and then continue 
+      // If there is no streaming required on any of the functions on the 
+      // way to `path`, then attempt to parse the fully buffered request stream
+      // once it has emitted the `end` event.
       //
-      req.once('end', parseAndInvoke)
-    }
-    else {
-      //
-      // Otherwise, just parse the body now. 
-      //
-      parseAndInvoke();
-    }
+      if (req.readable) {
+        //
+        // If the `http.ServerRequest` is still readable, then await
+        // the end event and then continue 
+        //
+        req.once('end', parseAndInvoke)
+      }
+      else {
+        //
+        // Otherwise, just parse the body now. 
+        //
+        parseAndInvoke();
+      }
+    });
   }
   else {
     this.invoke(runlist, thisArg, callback);


### PR DESCRIPTION
We should be using `process.nextTick` here because in the case of BufferedStreams (i.e. normally), the stream won't be set to not readable until the nextTick
