### PR TITLE
Removed deprecated getState() from browser.js

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -221,11 +221,6 @@ Router.prototype.insertEx = function(method, path, route, parent) {
   return this._insert(method, path, route, parent);
 };
 
-
-Router.prototype.getState = function () {
-  return this.state;
-};
-
 Router.prototype.getRoute = function (v) {
   var ret = v;
 


### PR DESCRIPTION
There was some discussion on #89 on what to do with the state situation that was supported sugarskull. It was decided that it would be deprecated, but the function was still included. A new build has **not** been generated.
