### PR TITLE
add "ender" keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "http",
     "cli",
     "flatiron",
-    "client side"
+    "client side",
+    "ender"
   ],
   "devDependencies": {
     "codesurgeon": "0.2.x",


### PR DESCRIPTION
since you have a nice Ender bridge you may as well have an "ender" keyword so you show up as an Ender compatible lib in an `ender search`.
Cheers.
