### PR TITLE
Allows http router.attach() to be called more than once.

### DIFF
--- a/lib/director/http/index.js
+++ b/lib/director/http/index.js
@@ -28,6 +28,7 @@ var Router = exports.Router = function (routes) {
   this.scope    = [];
   this._methods = {};
   this.recurse = 'forward';
+  this._attach = [];
 
   this.extend(exports.methods.concat(['before', 'after']));
   this.configure();
@@ -65,7 +66,7 @@ Router.prototype.on = function (method, path) {
 // Ask the router to attach objects or manipulate `this` object on which the
 // function passed to the http router will get applied
 Router.prototype.attach = function (func) {
-  this._attach = func;
+  this._attach.push(func);
 };
 
 //
@@ -91,7 +92,9 @@ Router.prototype.dispatch = function (req, res, callback) {
       error;
 
   if (this._attach) {
-    this._attach.call(thisArg);
+    for (var i in this._attach) {
+      this._attach[i].call(thisArg);
+    }
   }
 
   if (!fns || fns.length === 0) {


### PR DESCRIPTION
In a flatiron app I am working on, I would like to be able to call app.router.attach() multiple times (from different broadway plugins).  This small change would allow that to happen.

Tests pass, however, this IS technically an API change IF someone was calling attach() multiple times intentionally overriding the old handler.

One possible addition that I did not include would be an api to clear the attached handlers.  Not sure if that is necessary or not and what form that clear should take (for example, could be cleared with an empty call to attach()).
