### PR TITLE
[minor] options.stream can be set instead of setting stream for every route

### DIFF
--- a/lib/director/http/index.js
+++ b/lib/director/http/index.js
@@ -41,6 +41,20 @@ var Router = exports.Router = function (routes) {
 util.inherits(Router, director.Router);
 
 //
+// ### function configure (options)
+// #### @options {Object} **Optional** Options to configure this instance with
+// Configures this instance with the specified `options`.
+//
+Router.prototype.configure = function (options) {
+  options = options || {};
+
+  // useful when using connect's bodyParser
+  this.stream = options.stream || false;
+
+  director.Router.prototype.configure.call(this, options);
+}
+
+//
 // ### function on (method, path, route)
 // #### @method {string} **Optional** Method to use
 // #### @path {string} Path to set this route on.
@@ -113,7 +127,7 @@ Router.prototype.dispatch = function (req, res, callback) {
   }
 
   runlist = this.runlist(fns);
-  stream  = runlist.some(function (fn) { return fn.stream === true });
+  stream  = this.stream || runlist.some(function (fn) { return fn.stream === true });
 
   function parseAndInvoke() {
     error = self.parse(req);


### PR DESCRIPTION
If director is used with `connect.bodyParser()`, then all the route fns need to be set as `fn.stream = true` inorder for req.body to be present. This commit allows people to set it in the initial configuration itself instead of doing it for every function.
