### PR TITLE
Fixed misleading documentation in README.md, routing functions don't get passed the route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Director handles routing for HTTP requests similar to `journey` or `express`:
   //
   function helloWorld(route) {
     this.res.writeHead(200, { 'Content-Type': 'text/plain' })
-    this.res.end('hello world from (' + route + ')');
+    this.res.end('hello world');
   }
 
   //


### PR DESCRIPTION
Noticed this on npmjs.org, and saw there was a 10 month old issue (issue #45). The documentation should be updated if the feature is not present.
