### PR TITLE
Adding terminator to the router extraction for the client-side build.

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -46,6 +46,7 @@ surgeon
     '_asyncEverySeries',
     'paramifyString',
     'regifyString',
+    'terminator',
     'Router.prototype.configure',
     'Router.prototype.param',
     'Router.prototype.on',


### PR DESCRIPTION
When executing `bin/build`, the `terminator` function in `lib/director/router.js` is not being included in the extract.  This breaks the client-side router.  Here's a simple PR to fix that.
