### PR TITLE
Fixed some broken named anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [0]: http://github.com/flatiron/director
-[1]: https://github.com/flatiron/director/blob/master/build/director-1.1.6.min.js
+[1]: https://github.com/flatiron/director/blob/master/build/director.min.js
 [2]: http://github.com/flatiron/flatiron
 [3]: http://github.com/flatiron/union


### PR DESCRIPTION
I fixed some broken named anchors in the README.md that I came across while trying to find out if I'm encountering a bug.

The 'on' and 'before' methods do not seem to get called unless there is also an HTTP verb present. (server-side) Is this intended behavior or is a bug? If this is intended it might be helpful to add to the README.md.

example: https://gist.github.com/3813687
