### PR TITLE
Fix setRoute and getRoute in IE7

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -221,7 +221,7 @@ Router.prototype.init = function (r) {
 
 Router.prototype.explode = function () {
   var v = this.history === true ? this.getPath() : dloc.hash;
-  if (v[1] === '/') { v=v.slice(1) }
+  if (v.charAt(1) === '/') { v=v.slice(1) }
   return v.slice(1, v.length).split("/");
 };
 


### PR DESCRIPTION
There's a problem originating in explode() that causes the '#' to not be removed from the hash.

For example, if dloc.hash is '#/foo/bar', `getRoute(0)` returns an empty string in IE7 instead of 'foo'.

It's a simple fix. The problem is that the shortcut string index notation doesn't work consistently across browsers (see [discussion here](http://stackoverflow.com/questions/5943726/string-charatx-or-stringx)).
