### PR TITLE
[fix] Don't unconditionally expand wildcards. It breaks pure regex routes.

### DIFF
--- a/lib/director/router.js
+++ b/lib/director/router.js
@@ -91,9 +91,17 @@ function paramifyString(str, params, mod) {
 // "named" matches (:whatever)
 //
 function regifyString(str, params) {
-  if (~str.indexOf('*')) {
-    str = str.replace(/\*/g, '([_\.\(\)!\\ %@&a-zA-Z0-9-]+)');
+  var matches,
+      last = 0,
+      out = '';
+
+  while (matches = str.substr(last).match(/[^\w\d\- %@&]*\*[^\w\d\- %@&]*/)) {
+    last = matches.index + matches[0].length;
+    matches[0] = matches[0].replace(/^\*/, '([_\.\(\)!\\ %@&a-zA-Z0-9-]+)');
+    out += str.substr(0, matches.index) + matches[0];
   }
+
+  str = out += str.substr(last);
 
   var captures = str.match(/:([^\/]+)/ig),
       length;

--- a/test/server/core/regifystring-test.js
+++ b/test/server/core/regifystring-test.js
@@ -1,0 +1,103 @@
+
+var assert = require('assert'),
+    vows = require('vows'),
+    director = require('../../../lib/director');
+
+var callback = function() {
+  return true;
+};
+
+var testRoute = function(route, callback) {
+  var router = new director.Router();
+  router.on(route, callback);
+
+  return function(value) {
+    return router.dispatch('on', value);
+  };
+};
+
+vows.describe('director/core/regifyString').addBatch({
+
+  'When using "/home(.*)"': {
+    topic: function() {
+      return testRoute('/home(.*)', callback);
+    },
+
+    'Should match "/homepage"': function(result) {
+      assert.isTrue(result('/homepage'));
+    },
+
+    'Should match "/home/page"': function(result) {
+      assert.isTrue(result('/home/page'));
+    },
+
+    'Should not match "/foo-bar"': function(result) {
+      assert.isFalse(result('/foo-bar'));
+    }
+  },
+
+  'When using "/home.*"': {
+    topic: function() {
+      return testRoute('/home.*', callback);
+    },
+
+    'Should match "/homepage"': function(result) {
+      assert.isTrue(result('/homepage'));
+    },
+
+    'Should match "/home/page"': function(result) {
+      assert.isTrue(result('/home/page'));
+    },
+
+    'Should not match "/foo-bar"': function(result) {
+      assert.isFalse(result('/foo-bar'));
+    }
+  },
+
+  'When using "/home(page[0-9])*"': {
+    topic: function() {
+      return testRoute('/home(page[0-9])*', callback);
+    },
+
+    'Should match "/home"': function(result) {
+      assert.isTrue(result('/home'));
+    },
+
+    'Should match "/homepage0", "/homepage1", etc.': function(result) {
+      for (i = 0; i < 10; i++) {
+        assert.isTrue(result('/homepage' + i));
+      }
+    },
+
+    'Should not match "/home_page"': function(result) {
+      assert.isFalse(result('/home_page'));
+    },
+
+    'Should not match "/home/page"': function(result) {
+      assert.isFalse(result('/home/page'));
+    }
+  },
+
+  'When using "/home*"': {
+    topic: function() {
+      return testRoute('/home*', callback);
+    },
+
+    'Should match "/homepage"': function(result) {
+      assert.isTrue(result('/homepage'));
+    },
+
+    'Should match "/home_page"': function(result) {
+      assert.isTrue(result('/home_page'));
+    },
+
+    'Should match "/home-page"': function(result) {
+      assert.isTrue(result('/home-page'));
+    },
+
+    'Should not match "/home/page"': function(result) {
+      assert.isFalse(result('/home/page'));
+    }
+  }
+
+}).export(module);


### PR DESCRIPTION
This is related to #157.

Things like `home.*` currently get expanded to `home.([_\.\(\)!\\ %@&a-zA-Z0-9-]+)`. This fix prevents such an occurrence, and instead uses the correct `home.*` route.

Running a test case looks like:

``` js
var router = new director.Router({

  '/home(.*)/': callback,
  '/home(page)*': callback,
  '/home.*': callback,
  '/home(page*)': callback,
  '/home(page*)*': callback,
  '/home(page[0-9]*)': callback,
  '/home(page[0-9]*)*': callback,
  '/home(page[0-9])*': callback,
  '/home*': callback,
  '/home-*': callback,
  '/home-page*': callback,
  '/home%*': callback,
  '/home&*': callback,
  '/home(&*)': callback,
  '/*page': callback

});
```

```
home(.*)
home(page)*
home.*
home(page([_.()!\ %@&a-zA-Z0-9-]+))
home(page([_.()!\ %@&a-zA-Z0-9-]+))*
home(page[0-9]*)
home(page[0-9]*)*
home(page[0-9])*
home([_.()!\ %@&a-zA-Z0-9-]+)
home-([_.()!\ %@&a-zA-Z0-9-]+)
home-page([_.()!\ %@&a-zA-Z0-9-]+)
home%([_.()!\ %@&a-zA-Z0-9-]+)
home&([_.()!\ %@&a-zA-Z0-9-]+)
home(&([_.()!\ %@&a-zA-Z0-9-]+))
([_.()!\ %@&a-zA-Z0-9-]+)page
```

Test cases and feedback welcome.
