### PR TITLE
Fix the scope error when using .on() in the browser

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -175,6 +175,7 @@ var Router = exports.Router = function (routes) {
   this.params   = {};
   this.routes   = {};
   this.methods  = ['on', 'once', 'after', 'before'];
+  this.scope    = [];
   this._methods = {};
 
   this._insert = this.insert;


### PR DESCRIPTION
This should address Issue #76 (https://github.com/flatiron/director/issues/76)
