### PR TITLE
change http server callback function identity to match the normal api

### DIFF
--- a/lib/director/router.js
+++ b/lib/director/router.js
@@ -404,6 +404,8 @@ Router.prototype.runlist = function (fns) {
 // with false, or evaluation will short circuit.
 //
 Router.prototype.invoke = function (fns, thisArg, callback) {
+  var isHttpServerCallback = false
+  if (thisArg.req && thisArg.res) isHttpServerCallback = true
   var self = this;
 
   if (this.async) {
@@ -431,7 +433,9 @@ Router.prototype.invoke = function (fns, thisArg, callback) {
         return _every(fn, apply);
       }
       else if (typeof fn === 'function') {
-        return fn.apply(thisArg, fns.captures || []);
+        var args = fns.captures || []
+        if (isHttpServerCallback) args = [thisArg.req, thisArg.res].concat(args)
+        return fn.apply(thisArg, args);
       }
       else if (typeof fn === 'string' && self.resource) {
         self.resource[fn].apply(thisArg, fns.captures || []);

--- a/test/server/helpers/index.js
+++ b/test/server/helpers/index.js
@@ -20,7 +20,7 @@ exports.createServer = function (router) {
 };
 
 exports.handlers = {
-  respondWithId: function (id) {
+  respondWithId: function (req, res, id) {
     this.res.writeHead(200, { 'Content-Type': 'text/plain' })
     this.res.end('hello from (' + id + ')');
   },


### PR DESCRIPTION
I wanted to do this (so that I could use the many functions on NPM that accept the `(req, res)` identity):

``` javascript
router.get('/', function(req, res) {
  res.end('hello')
})
```

instead of this

``` javascript
router.get('/', function() {
  this.res.end('hello')
})
```

there might be a better way to implement this but given the level of abstraction inside the director codebase I couldn't figure out anything more elegant. I also made sure all the tests still pass
