### PR TITLE
Add ability to skip routing on a particular setRoute() call.

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -37,6 +37,7 @@ var listener = {
   mode: 'modern',
   hash: dloc.hash,
   history: false,
+  skip: false,
 
   check: function () {
     var h = dloc.hash;
@@ -64,9 +65,12 @@ var listener = {
     }
 
     function onchange(onChangeEvent) {
-      for (var i = 0, l = Router.listeners.length; i < l; i++) {
-        Router.listeners[i](onChangeEvent);
+      if (!self.skip) {
+        for (var i = 0, l = Router.listeners.length; i < l; i++) {
+          Router.listeners[i](onChangeEvent);
+        }
       }
+      self.skip = false;
     }
 
     //note IE8 is being counted as 'modern' because it has the hashchange event
@@ -226,19 +230,22 @@ Router.prototype.explode = function () {
   return v.slice(1, v.length).split("/");
 };
 
-Router.prototype.setRoute = function (i, v, val) {
+Router.prototype.setRoute = function (i, v, val, skip) {
   var url = this.explode();
 
   if (typeof i === 'number' && typeof v === 'string') {
     url[i] = v;
+    skip = val;
   }
   else if (typeof val === 'string') {
     url.splice(i, v, s);
   }
   else {
     url = [i];
+    skip = v;
   }
 
+  listener.skip = skip;
   listener.setHash(url.join('/'));
   return url;
 };


### PR DESCRIPTION
I'm submitting this pull request even though I'm not sure it's the proper solution.  I'd like to be able to set the route without triggering routing in a specific case.  I don't see any better way to accomplish that, but I'm open to suggestions on how this code could be improved.

As it stands, this code is fulfilling my need.  I can do:

```
setRoute( someRoute, true );
```

and routing will not fire for that particular setRoute() call.

Please let me know what you think of this change.
