### PR TITLE
limiting the character set for parameters

### DIFF
--- a/lib/director/router.js
+++ b/lib/director/router.js
@@ -103,7 +103,7 @@ function regifyString(str, params) {
 
   str = out += str.substr(last);
 
-  var captures = str.match(/:([^\/]+)/ig),
+  var captures = str.match(/:([a-zA-Z0-9_-]+)/ig),
       length;
 
   if (captures) {


### PR DESCRIPTION
limiting the character set for parameters makes it possible for example to add regular expressions after parameters. 
Before the regexp was seen as part of the parameter name. Also i don't think you want to use any special characters in the parameter names like %:*...

Right now only a-z A-Z 0-9 - and _ is added, am i maybe missing any characters that should be added?
