### PR TITLE
req.resume(); for http streams2 compat

### DIFF
--- a/lib/director/http/index.js
+++ b/lib/director/http/index.js
@@ -187,6 +187,9 @@ Router.prototype.dispatch = function (req, res, callback) {
       // the end event and then continue
       //
       req.once('end', parseAndInvoke);
+      // Streams2 requires us to start the stream if we're not explicitly
+      // reading from it.
+      req.resume();
     }
     else {
       //


### PR DESCRIPTION
I couldn't get vows to run, I guess another 0.10 problem? So I didn't even bother looking for a relevant test, let alone write a new one for it.
