### PR TITLE
Updated version of vows from 0.6.x to 0.7.x. Fixes #192

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "uglify-js": "1.0.6",
     "request": "2.9.x",
     "qunitjs": "1.9.x",
-    "vows": "0.6.x"
+    "vows": "0.7.x"
   },
   "ender": "./build/ender.js",
   "browserify": "./build/director",


### PR DESCRIPTION
The unit tests wouldn't run in node `v0.10.3`, and upgrading vows to the latest version fixed it so the test run (and pass).
