### PR TITLE
Update browser.js

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -1,4 +1,3 @@
-
 /*
  * browser.js: Browser specific functionality for director.
  *
@@ -192,7 +191,7 @@ Router.prototype.init = function (r) {
   this.handler = function(onChangeEvent) {
     var newURL = onChangeEvent && onChangeEvent.newURL || window.location.hash;
     var url = self.history === true ? self.getPath() : newURL.replace(/.*#/, '');
-    self.dispatch('on', url[0] === '/' ? url : '/' + url);
+    self.dispatch('on', url.charAt(0) === '/' ? url : '/' + url);
   };
 
   listener.init(this.handler, this.history);


### PR DESCRIPTION
changed url[0] to url.charAt(0), because IE7 not support to get the first char of a string like this:  string[0];
