### PR TITLE
Fix IE8 variable hoisting of apply function in  if/else.

### DIFF
--- a/lib/director/router.js
+++ b/lib/director/router.js
@@ -414,15 +414,17 @@ Router.prototype.runlist = function (fns) {
 Router.prototype.invoke = function (fns, thisArg, callback) {
   var self = this;
 
+  var apply;
   if (this.async) {
-    _asyncEverySeries(fns, function apply(fn, next) {
+    apply = function(fn, next){
       if (Array.isArray(fn)) {
         return _asyncEverySeries(fn, apply, next);
       }
       else if (typeof fn == 'function') {
         fn.apply(thisArg, fns.captures.concat(next));
       }
-    }, function () {
+    };
+    _asyncEverySeries(fns, apply, function () {
       //
       // Ignore the response here. Let the routed take care
       // of themselves and eagerly return true.
@@ -434,7 +436,7 @@ Router.prototype.invoke = function (fns, thisArg, callback) {
     });
   }
   else {
-    _every(fns, function apply(fn) {
+    apply = function(fn){
       if (Array.isArray(fn)) {
         return _every(fn, apply);
       }
@@ -444,7 +446,8 @@ Router.prototype.invoke = function (fns, thisArg, callback) {
       else if (typeof fn === 'string' && self.resource) {
         self.resource[fn].apply(thisArg, fns.captures || []);
       }
-    });
+    }
+    _every(fns, apply);
   }
 };
 


### PR DESCRIPTION
Hi!

This fixes a bug where a function declaration was used as a function expression (e.g the different between `function foo(){}` and `var foo = function(){}`). This causes errors in IE8 that breaks async routing (and possible in other implementations as well, see http://stackoverflow.com/a/10069457).

This changes apply to a function expression instead.
