### PR TITLE
Protect against exception when onpopstate/onhashchange are null

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -47,7 +47,8 @@ var listener = {
 
   fire: function () {
     if (this.mode === 'modern') {
-      this.history === true ? window.onpopstate() : window.onhashchange();
+      var method = window[this.history === true ? 'onpopstate' : 'onhashchange'];
+      method && method();
     }
     else {
       this.onHashChanged();


### PR DESCRIPTION
Without this patch, the following will throw an exception:

```
router = Router(routes)
router.configure({
  notfound: function() { router.setRoute('/'); }
});
router.init();
```

In the early stages of page load, `window.onpopstate` and `window.onhashchange` are `null` (in Chrome, anyway).
