### PR TITLE
[fix] escape regex special characters

### DIFF
--- a/lib/director/router.js
+++ b/lib/director/router.js
@@ -548,7 +548,7 @@ Router.prototype.traverse = function (method, path, routes, regexp, filter) {
         exact += '[' + this.delimiter + ']?';
       }
 
-      match = path.match(new RegExp('^' + exact));
+      match = path.match(new RegExp("^" + exact.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")));
 
       if (!match) {
         //


### PR DESCRIPTION
Escape a character that has special meaning inside a regular expression with a \ character.

For example, router doesn't work properly with links, containing parentheses or other special symbols (using in regex too) without escaping. 
