### PR TITLE
Fix error when user clicks a link within 500ms

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -55,14 +55,7 @@ var listener = {
       || document.documentMode > 7)) {
       // At least for now HTML5 history is available for 'modern' browsers only
       if (this.history === true) {
-        // There is an old bug in Chrome that causes onpopstate to fire even
-        // upon initial page load. Since the handler is run manually in init(),
-        // this would cause Chrome to run it twise. Currently the only
-        // workaround seems to be to set the handler after the initial page load
-        // http://code.google.com/p/chromium/issues/detail?id=63040
-        setTimeout(function() {
-          window.onpopstate = onchange;
-        }, 500);
+        window.onpopstate = onchange;
       }
       else {
         window.onhashchange = onchange;


### PR DESCRIPTION
This Chrome "bug fix" can be removed now per #233. Chrome 39 is now in production and the "fix" has a big drawback of throwing an error if the user clicks a link within 500ms of director initialization.

Closes #233 