### PR TITLE
Remove 500ms setTimeout for the window.onpopstate assignment.

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -55,14 +55,7 @@ var listener = {
       || document.documentMode > 7)) {
       // At least for now HTML5 history is available for 'modern' browsers only
       if (this.history === true) {
-        // There is an old bug in Chrome that causes onpopstate to fire even
-        // upon initial page load. Since the handler is run manually in init(),
-        // this would cause Chrome to run it twise. Currently the only
-        // workaround seems to be to set the handler after the initial page load
-        // http://code.google.com/p/chromium/issues/detail?id=63040
-        setTimeout(function() {
-          window.onpopstate = onchange;
-        }, 500);
+        window.onpopstate = onchange;
       }
       else {
         window.onhashchange = onchange;


### PR DESCRIPTION
The old Chrome bug has been reported to be fixed.
http://code.google.com/p/chromium/issues/detail?id=63040
Initial testings in my app using this lib show that the route handlers aren't called twice on initial page load and after hard refreshes after this change.