### PR TITLE
[BUG] Could not set recurse = false via call to configure()

### DIFF
--- a/lib/director/router.js
+++ b/lib/director/router.js
@@ -194,7 +194,7 @@ Router.prototype.configure = function (options) {
     this._methods[this.methods[i]] = true;
   }
 
-  this.recurse   = options.recurse   || this.recurse || false;
+  this.recurse   = typeof options.recurse === 'undefined' ? this.recurse || false : options.recurse;
   this.async     = options.async     || false;
   this.delimiter = options.delimiter || '\/';
   this.strict    = typeof options.strict === 'undefined' ? true : options.strict;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "qunitjs": "1.9.x",
     "request": "2.49.x",
     "uglify-js": "2.4.x",
-    "vows": "0.7.x"
+    "vows": "0.8.0"
   },
   "ender": "./build/ender.js",
   "browserify": "./build/director",

--- a/test/server/http/configure-test.js
+++ b/test/server/http/configure-test.js
@@ -1,0 +1,37 @@
+/*
+ * on-test.js: Tests for the on/route method.
+ *
+ * (C) 2011, Charlie Robbins, Paolo Fragomeni, & the Contributors.
+ * MIT LICENSE
+ *
+ */
+
+var assert = require('assert'),
+    vows = require('vows'),
+    director = require('../../../lib/director');
+
+vows.describe('director/core/configure').addBatch({
+  "An instance of director.Router": {
+    topic: new director.http.Router(),
+    "the configure() method": {
+      "called with an empty object": {
+        "should default recurse to 'forward'": function(router) {
+          router.configure({});
+          assert.strictEqual(router.recurse, 'forward');
+        }
+      },
+      "called with recurse = false": {
+        "should set recurse to false": function(router) {
+          router.configure({ recurse: false });
+          assert.strictEqual(router.recurse, false);
+        }
+      },
+      "called with recurse = 'backward'": {
+        "should set recurse to 'backward'": function(router) {
+          router.configure({ recurse: 'backward' });
+          assert.strictEqual(router.recurse, 'backward');
+        }
+      }
+    }
+  }
+}).export(module);


### PR DESCRIPTION
Any call to the router.configure() method, where recurse was set to false was being ignored. 

A fix, some tests, and also I fixed your issue with your tests failing. 