### PR TITLE
[BUG]: Arrays with modified prototypes breaks attach() logic

### DIFF
--- a/lib/director/http/index.js
+++ b/lib/director/http/index.js
@@ -140,7 +140,7 @@ Router.prototype.dispatch = function (req, res, callback) {
   }
 
   if (this._attach) {
-    for (var i in this._attach) {
+    for (var i=0;i< this._attach.length; i++) {
       this._attach[i].call(thisArg);
     }
   }


### PR DESCRIPTION
If you've modified Array.prototype, the attach logic was previously trying to iterate over the added methods to Array.prototype when binding attach() calls.

This patch solves the issue.