### PR TITLE
add Array.isArray and Array.filter function for old IE browsers.

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -6,6 +6,28 @@
  *
  */
 
+Array.isArray = Array.isArray || function (obj) {
+	return Object.prototype.toString.call(obj) === '[object Array]';
+};
+
+Array.prototype.filter = Array.prototype.filter || function(fun){  
+        var len = this.length;  
+        if (typeof fun != "function"){  
+            throw new TypeError();  
+        }  
+        var res = new Array();  
+        var thisp = arguments[1];  
+        for (var i = 0; i < len; i++){  
+            if (i in this){  
+                var val = this[i];  
+                if (fun.call(thisp, val, i, this)) {  
+                    res.push(val);  
+                }  
+            }  
+        }  
+        return res;  
+};
+  
 var dloc = document.location;
 
 function dlocHashEmpty() {


### PR DESCRIPTION
add Array.isArray and Array.filter function for old IE browsers, so that directorjs can used in old IE browsers without any other polyfill libraries
