### PR TITLE
Fixing README so it points to the right Router class path

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Director handles routing for HTTP requests similar to `journey` or `express`:
   //
   // define a routing table.
   //
-  var router = new director.http.Router({
+  var router = new director.Router({
     '/hello': {
       get: helloWorld
     }
@@ -341,7 +341,7 @@ adhoc routing:
 **HTTP Routing**
 
 ``` js
-  var router = new director.http.Router();
+  var router = new director.Router();
 
   router.get(/\/some\/resource/, function () {
     //
@@ -358,7 +358,7 @@ resources. Director exposes a simple way to do this for [Adhoc
 Routing](#adhoc-routing) scenarios:
 
 ``` js
-  var router = new director.http.Router();
+  var router = new director.Router();
 
   //
   // Create routes inside the `/users` scope.
@@ -512,7 +512,7 @@ simple example where a `userId` is used repeatedly.
 ``` js
   //
   // Create a router. This could also be director.cli.Router() or
-  // director.http.Router().
+  // director.Router().
   //
   var router = new director.Router();
 
@@ -670,7 +670,7 @@ callback.
 ### Asynchronous route functions
 
 ``` js
-  var router = new director.http.Router().configure({ async: true });
+  var router = new director.Router().configure({ async: true });
 
   router.on('/:foo/:bar/:bazz', function (foo, bar, bazz, next) {
     //
@@ -735,7 +735,7 @@ route handlers, will contain the request in `this.req` and the response in
 ```js
   var director = require('director');
 
-  var router = new director.http.Router().configure(options);
+  var router = new director.Router().configure(options);
 
   //
   // Attach properties to `this`
@@ -769,7 +769,7 @@ When you are performing HTTP routing there are two common scenarios:
 * Stream the request body by manually calling `.pipe` or listening to the
   `data` and `end` events.
 
-By default `director.http.Router()` will attempt to parse either the `.chunks`
+By default `director.Router()` will attempt to parse either the `.chunks`
 or `.body` properties set on the request parameter passed to
 `router.dispatch(request, response, callback)`. The router instance will also
 wait for the `end` event before firing any routes.
@@ -779,7 +779,7 @@ wait for the `end` event before firing any routes.
 ``` js
   var director = require('director');
 
-  var router = new director.http.Router();
+  var router = new director.Router();
 
   router.get('/', function () {
     //
@@ -802,7 +802,7 @@ you can use a simple request handler in your http server:
   var http = require('http'),
       director = require('director');
 
-  var router = new director.http.Router();
+  var router = new director.Router();
 
   var server = http.createServer(function (req, res) {
     req.chunks = [];
@@ -834,7 +834,7 @@ fired, you can pass the `{ stream: true }` options to the route.
 ``` js
   var director = require('director');
 
-  var router = new director.http.Router();
+  var router = new director.Router();
 
   router.get('/', { stream: true }, function () {
     //


### PR DESCRIPTION
Hello, congrats for the project. I'm using `1.2.8` and I noticed [here](https://github.com/flatiron/director/blob/master/lib/director.js) that the `Router` class is no longer part of the `http` module. So `director.http.Router` leads to an error. The README is not updated and I spent few minutes wondering what's wrong.
