### PR TITLE
Expose function to check if router is bound to window.onhashchange

### DIFF
--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -93,6 +93,7 @@ var listener = {
       this.mode = 'legacy';
     }
 
+    this.initOnchange = onchange;
     Router.listeners.push(fn);
 
     return this.mode;
@@ -145,6 +146,10 @@ var listener = {
       dloc.hash = s;
     }
     return this;
+  },
+
+  isOnHashChange: function() {
+    return window.onhashchange === this.initOnchange;
   },
 
   onHashChanged: function () {}
@@ -283,4 +288,8 @@ Router.prototype.getPath = function () {
     path = '/' + path;
   }
   return path;
+};
+
+Router.prototype.isOnHashChange = function() {
+  return listener.isOnHashChange();
 };


### PR DESCRIPTION
#When using this technology in an application exposed in an iFrame in a Salesforce community portal, we have an issue that the window.onhashchange is being overwritten by the portal we are embedded in after we initialize our routing. Thus, exposing a method to check this allows us to destroy and recreate the route if we are no longer hooked into the window.onhashchange handling. 