### PR TITLE
docs: Fix simple typo, twise -> twice

### DIFF
--- a/build/director.js
+++ b/build/director.js
@@ -66,7 +66,7 @@ var listener = {
       if (this.history === true) {
         // There is an old bug in Chrome that causes onpopstate to fire even
         // upon initial page load. Since the handler is run manually in init(),
-        // this would cause Chrome to run it twise. Currently the only
+        // this would cause Chrome to run it twice. Currently the only
         // workaround seems to be to set the handler after the initial page load
         // http://code.google.com/p/chromium/issues/detail?id=63040
         setTimeout(function() {

--- a/lib/director/browser.js
+++ b/lib/director/browser.js
@@ -57,7 +57,7 @@ var listener = {
       if (this.history === true) {
         // There is an old bug in Chrome that causes onpopstate to fire even
         // upon initial page load. Since the handler is run manually in init(),
-        // this would cause Chrome to run it twise. Currently the only
+        // this would cause Chrome to run it twice. Currently the only
         // workaround seems to be to set the handler after the initial page load
         // http://code.google.com/p/chromium/issues/detail?id=63040
         setTimeout(function() {


### PR DESCRIPTION
There is a small typo in build/director.js, lib/director/browser.js.

Should read `twice` rather than `twise`.

